### PR TITLE
fix(index): gracefully exit process

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,8 @@ module.exports = (opts) => {
           close(() => {
             log.info(`Process Ended via ${sig}`);
             server.kill();
-            process.exit(0);
+            // gracefully exit the process
+            process.exitCode = 0;
           });
         });
       }


### PR DESCRIPTION
It is a misuse of `process.exit()` to write to stdout and call `process.exit` to terminate the process synchronously. And most of time it is not necessary to call `process.exit`, see https://nodejs.org/api/process.html#process_process_exit_code

<!--
  ZOMG a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and @ken_wheeler
  will appear and pile-drive the close button from a great height while making
  animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**