### PR TITLE
Fix event emitter example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,16 +319,16 @@ The port the server should listen on.
 
 ## Events
 
-`webpack-serve` emits select events which can be subscribed to. For example;
+The server created by `webpack-serve` emits select events which can be subscribed to. For example;
 
 ```js
 const serve = require('webpack-serve');
 const config = require('./webpack.config.js');
 
-serve({ config });
-
-serve.on('listening', () => {
-  console.log('happy fun time');
+serve({ config }).then((server) => {
+  server.on('listening', () => {
+    console.log('happy fun time');
+  });
 });
 ```
 


### PR DESCRIPTION
<!--
  ZOMG a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and @ken_wheeler
  will appear and pile-drive the close button from a great height while making
  animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**
- [x] **documentation fix** (none of the categories above seemed to apply…)

`serve.on` is undefined, so the current example under the "Events" heading errors out. I've copied the approach used in the event unit tests: https://github.com/webpack-contrib/webpack-serve/blob/bb84692969a672eaa18865c98f6f045aa57bf3c5/test/tests/events.js