### PR TITLE
Simplify proxy addon example

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Listed below are some of the add-on patterns and recipes that can be found in
 - [compress](docs/addons/compress)
 - [historyApiFallback](docs/addons/history-fallback.config.js)
 - [proxy](docs/addons/proxy.config.js)
+- [spa-with-api-simple](docs/addons/spa-with-api-simple.config.js)
 - [staticOptions](docs/addons/static-content-options.config.js)
 - [useLocalIp](docs/addons/local-ip.config.js)
 

--- a/docs/addons/proxy.config.js
+++ b/docs/addons/proxy.config.js
@@ -3,6 +3,17 @@
 const path = require('path');
 const proxy = require('http-proxy-middleware');
 const convert = require('koa-connect');
+const Router = require('koa-router');
+
+const router = new Router();
+
+const proxyOptions = {
+  target: 'http://api.github.com',
+  changeOrigin: true
+  // ... see: https://github.com/chimurai/http-proxy-middleware#options
+};
+
+router.get('*', convert(proxy(proxyOptions)));
 
 module.exports = {
   entry: {
@@ -17,12 +28,12 @@ module.exports = {
 module.exports.serve = {
   content: [__dirname],
   add: (app, middleware, options) => {
-    const proxyOptions = {
-      target: 'http://reqres.in/',
-      changeOrigin: true
-      // ... see: https://github.com/chimurai/http-proxy-middleware#options
-    };
+    // since we're manipulating the order of middleware added, we need to handle
+    // adding these two internal middleware functions.
+    middleware.webpack();
+    middleware.content();
 
-    app.use(convert(proxy('/api', proxyOptions)));
+    // router *must* be the last middleware added
+    app.use(router.routes());
   }
 };

--- a/docs/addons/proxy.config.js
+++ b/docs/addons/proxy.config.js
@@ -3,17 +3,6 @@
 const path = require('path');
 const proxy = require('http-proxy-middleware');
 const convert = require('koa-connect');
-const Router = require('koa-router');
-
-const router = new Router();
-
-const proxyOptions = {
-  target: 'http://api.github.com',
-  changeOrigin: true
-  // ... see: https://github.com/chimurai/http-proxy-middleware#options
-};
-
-router.get('*', convert(proxy(proxyOptions)));
 
 module.exports = {
   entry: {
@@ -28,12 +17,12 @@ module.exports = {
 module.exports.serve = {
   content: [__dirname],
   add: (app, middleware, options) => {
-    // since we're manipulating the order of middleware added, we need to handle
-    // adding these two internal middleware functions.
-    middleware.webpack();
-    middleware.content();
+    const proxyOptions = {
+      target: 'http://reqres.in/',
+      changeOrigin: true
+      // ... see: https://github.com/chimurai/http-proxy-middleware#options
+    };
 
-    // router *must* be the last middleware added
-    app.use(router.routes());
+    app.use(convert(proxy('/api', proxyOptions)));
   }
 };

--- a/docs/addons/spa-with-api-simple.config.js
+++ b/docs/addons/spa-with-api-simple.config.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const path = require('path');
+
+const history = require('connect-history-api-fallback');
+const proxy = require('http-proxy-middleware');
+const convert = require('koa-connect');
+
+module.exports = {
+  entry: {
+    index: [path.resolve(__dirname, 'app.js')]
+  },
+  mode: 'development',
+  output: {
+    filename: 'output.js'
+  }
+};
+
+module.exports.serve = {
+  content: [__dirname],
+  add: (app, middleware, options) => {
+    app.use(convert(proxy('/api', { target: 'http://localhost:8081' })));
+    app.use(convert(history()));
+  }
+};
+
+// This add-on will route all incoming requests for
+// "http://localhost:8080/api/*" to "http://localhost:8081/api/*" (note the port
+// change), and all remaining requests, which would otherwise result in 404,
+// will be rewritten to serve your "index.html", which is useful for single-page
+// applications.
+// 
+// To remove the "/api" prefix when proxying the API requests, just add
+// "pathRewrite: { '^/api': '' }" to proxy's options.
+// 
+// Proxy's docs: https://github.com/chimurai/http-proxy-middleware
+// Fallback's docs: https://github.com/bripkens/connect-history-api-fallback


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Updated the proxy addon example to be closer to what people probably use it for in the context of `webpack-serve` / `webpack-dev-server`. Routing usually isn't needed with `http-proxy`, and when it is, `koa-mount` would probably be a better fit.

### Additional Info

I think a combined example of HTTP proxy + history API fallback is warranted, but I want to know whether you think it's needed or not first, before adding it.

Also, would be nice to have all examples `koa-connect`-free. I can see why they aren't right now, the existing Koa 2 equivalent libs are a bit sub par, but that's addressable.