### PR TITLE
Add CORS header to allow serving of files from different hosts

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -47,6 +47,10 @@ module.exports = (options) => {
       middleware.content.called = true;
       for (const dir of options.content) {
         app.use(serveStatic(dir, staticOptions || {}));
+        app.use((ctx, next) => {
+          ctx.set('Access-Control-Allow-Origin', '*');
+          next();
+        });
       }
     }
   };


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [x] new **feature**

### Motivation / Use-Case

I'm having a server side prerendered React application running on port 8500 and serve files which are built using `webpack-serve` in CLI mode on port 8080. That results in an error:
> _Failed to load http://localhost:8080/static/70a4aeb6b1596bc852d3.hot-update.json: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost:8500' is therefore not allowed access._

I was wondering if I'm using it incorrectly since I found nobody with similar issues here in the issue board but adding a simple `Access-Control-Allow-Origin: *` header fixed it for me. 

### Breaking Changes

Content is now served with `Access-Control-Allow-Origin: *` which in production environments might be a security risk but since `webpack-serve` is typically only used in dev environments I don't think this is critical.
