### PR TITLE
Options: If using pfx ensure a buffer is used

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -1,4 +1,6 @@
 const fs = require('fs');
+const path = require('path');
+
 const merge = require('lodash/merge');
 const weblog = require('webpack-log');
 
@@ -69,7 +71,7 @@ module.exports = (opts) => {
     if (https) {
       if (https.pfx && fs.lstatSync(https.pfx).isFile())
         https.pfx = fs.readFileSync(path.resolve(https.pfx));
-      
+
       options.https = https;
     }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const merge = require('lodash/merge');
 const weblog = require('webpack-log');
 
@@ -66,6 +67,9 @@ module.exports = (opts) => {
     const open = pull(flags, 'open');
 
     if (https) {
+      if (https.pfx && fs.lstatSync(https.pfx).isFile())
+        https.pfx = fs.readFileSync(https.pfx);
+      
       options.https = https;
     }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -68,7 +68,7 @@ module.exports = (opts) => {
 
     if (https) {
       if (https.pfx && fs.lstatSync(https.pfx).isFile())
-        https.pfx = fs.readFileSync(https.pfx);
+        https.pfx = fs.readFileSync(path.resolve(https.pfx));
       
       options.https = https;
     }


### PR DESCRIPTION
<!--
  ZOMG a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and @ken_wheeler
  will appear and pile-drive the close button from a great height while making
  animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Using this with pfx ssl was error-prone since the documentation did not mention that a pfx file buffer was required. Rather the documentation states 

>--https-pfx         Specify a pfx file to enable https. Must be paired with a passphrase

which sounds rather like the server expects a _path_ to a file.

In this PR we check to see if the value of `https.fpx` is a valid path to a file and if it is we assign the buffer of the read-in file to `https.pfx`. If the value of `https.pfx` cannot be resolved as a path, we assume it is an appropriate buffer. 

### Additional Info
Padding the README with instructions to provide a unencoded buffer (ie, invoking `fs.readFileSync()` without an encoding param) would probably decrease the rate of issues using this options.