### PR TITLE
feat: support named pipes

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -34,13 +34,13 @@ module.exports = {
     const { host, port } = options;
     let promise;
 
-		if (options.port === 0) {
-			promise = Promise.resolve(0);
-		} else if (typeof options.port === 'string') {
-			promise = Promise.resolve(options.port);
-		} else {
-			promise = getPort({ port, host });
-		}
+    if (options.port === 0) {
+      promise = Promise.resolve(0);
+    } else if (typeof options.port === 'string') {
+      promise = Promise.resolve(options.port);
+    } else {
+      promise = getPort({ port, host });
+    }
 
     return promise.then((freePort) => {
       if (typeof options.add === 'function') {

--- a/lib/app.js
+++ b/lib/app.js
@@ -34,11 +34,13 @@ module.exports = {
     const { host, port } = options;
     let promise;
 
-    if (options.port === 0) {
-      promise = Promise.resolve(0);
-    } else {
-      promise = getPort({ port, host });
-    }
+		if (options.port === 0) {
+			promise = Promise.resolve(0);
+		} else if (typeof options.port === 'string') {
+			promise = Promise.resolve(options.port);
+		} else {
+			promise = getPort({ port, host });
+		}
 
     return promise.then((freePort) => {
       if (typeof options.add === 'function') {


### PR DESCRIPTION


<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
Currently the `getPort` method is always called if `port` is set to anything but `0`. This causes an issue because `getPort` calls `const port = server.address().port` which doesn't return the correct value when using named pipes. 

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes
Potentially breaks if the port number is passed as a string i.e. an environment variable. Any ideas on how we could improve this?

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
This is important for use cases involving `iisnode` and similar that interact with the node process via a named pipe as the port instead.