### PR TITLE
feat(cli): use input as serve config instead of alias to `--config` (`.serverc`)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,12 +8,13 @@ if (!module.parent) {
   register();
 }
 
+const { isAbsolute, resolve } = require('path');
+
 const { getHelp, getOpts } = require('@webpack-contrib/cli-utils');
 const chalk = require('chalk');
 const cosmiconfig = require('cosmiconfig');
 const debug = require('debug')('webpack-serve');
 const meow = require('meow');
-const merge = require('merge-options').bind({ concatArrays: true });
 const importLocal = require('import-local'); // eslint-disable-line import/order
 
 // Prefer the local installation of webpack-serve
@@ -34,6 +35,9 @@ const cli = meow(
 {underline Usage}
   $ webpack-serve <config> [...options]
 
+{underline <config>}
+  Custom serve config file instead of default search path.
+
 {underline Options}
 ${help}
 
@@ -49,16 +53,20 @@ e.g. --no-reload rather than --reload=false}
 );
 
 const argv = Object.assign({}, cli.flags);
-const explorer = cosmiconfig('serve', {});
-// webpack-serve config from serve.config.js or supported format
-const { config: serveConfig = {} } = explorer.searchSync() || {};
-let config;
+
+const explorer = cosmiconfig('serve');
+let result;
 
 if (cli.input.length) {
-  [config] = cli.input;
+  let [configPath] = cli.input;
+  if (!isAbsolute(configPath)) {
+    configPath = resolve(process.cwd(), configPath);
+  }
+  result = explorer.loadSync(configPath);
+} else {
+  result = explorer.searchSync();
 }
-
-const options = merge({}, serveConfig, { config });
+const { config: options = {} } = result || {};
 
 serve(argv, options).catch(() => {
   /* istanbul ignore next */

--- a/schemas/flags.js
+++ b/schemas/flags.js
@@ -6,7 +6,7 @@ module.exports = {
     type: 'boolean',
   },
   config: {
-    desc: 'The webpack config to serve. Alias for <config>',
+    desc: 'The webpack config to serve.',
     type: 'string',
   },
   content: {
@@ -14,7 +14,8 @@ module.exports = {
     type: 'string',
   },
   'dev-ware': {
-    desc: 'Set options for webpack-dev-middleware. e.g. --dev-ware.publicPath /',
+    desc:
+      'Set options for webpack-dev-middleware. e.g. --dev-ware.publicPath /',
     type: 'object',
   },
   help: {

--- a/test/__snapshots__/cli.test.js.snap
+++ b/test/__snapshots__/cli.test.js.snap
@@ -7,9 +7,12 @@ exports[`cli --help 1`] = `
   Usage
     $ webpack-serve <config> [...options]
 
+  <config>
+    Custom serve config file instead of default search path.
+
   Options
     --clipboard      Specify whether or not the server should copy the server URI to the clipboard (default: true)
-    --config         The webpack config to serve. Alias for <config>
+    --config         The webpack config to serve.
     --content        The path from which static content will be served (default: process.cwd)
     --dev-ware       Set options for webpack-dev-middleware. e.g. --dev-ware.publicPath /
     --help           Show usage information and the options listed here.
@@ -45,7 +48,7 @@ exports[`cli --help 1`] = `
 `;
 
 exports[`cli bad config 1`] = `
-"Command failed: <PROJECT_ROOT>/lib/cli.js ./test/fixtures/invalid.config.js
+"Command failed: <PROJECT_ROOT>/lib/cli.js --config ./test/fixtures/invalid.config.js
 
 ValidationError: config-loader
 
@@ -55,7 +58,7 @@ ValidationError: config-loader
 `;
 
 exports[`cli config throwing error 1`] = `
-"Command failed: <PROJECT_ROOT>/lib/cli.js ./test/fixtures/error.config.js
+"Command failed: <PROJECT_ROOT>/lib/cli.js --config ./test/fixtures/error.config.js
 <PROJECT_ROOT>/test/fixtures/error.config.js:3
   throw new Error('batman');
   ^

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -48,18 +48,6 @@ describe('cli', () => {
     });
   });
 
-  test('[config]', () => {
-    const config = './test/fixtures/basic/webpack.config.js';
-    const proc = run([config, '--port', '9090']);
-
-    return proc.ready.then(() =>
-      request('http://localhost:9090')
-        .get('/output.js')
-        .expect(200)
-        .then(() => proc.kill('SIGINT'))
-    );
-  });
-
   test('--config', () => {
     const config = './test/fixtures/basic/webpack.config.js';
     const proc = run(['--config', config, '--port', '8888']);
@@ -74,7 +62,7 @@ describe('cli', () => {
 
   test('bad config', () => {
     const config = './test/fixtures/invalid.config.js';
-    const proc = run([config]);
+    const proc = run(['--config', config]);
 
     return proc.catch((e) => {
       const message = e.message
@@ -90,7 +78,7 @@ describe('cli', () => {
 
   test('config throwing error', () => {
     const config = './test/fixtures/error.config.js';
-    const proc = run([config]);
+    const proc = run(['--config', config]);
 
     return proc.catch((e) => {
       const message = e.message.split(/\n\s+at/);
@@ -102,10 +90,23 @@ describe('cli', () => {
   test('serve.config.js', () => {
     const config = './basic/webpack.config.js';
     const cwd = join(__dirname, 'fixtures');
-    const proc = run([config], { cwd });
+    const proc = run(['--config', config], { cwd });
 
     return proc.ready.then(() =>
       request('http://0.0.0.0:8080')
+        .get('/output.js')
+        .expect(200)
+        .then(() => proc.kill('SIGINT'))
+    );
+  });
+
+  test('[config]', () => {
+    const serveConfig = './test/fixtures/basic/custom-serve.config.js';
+    const config = './test/fixtures/basic/webpack.config.js';
+    const proc = run([serveConfig, '--config', config]);
+
+    return proc.ready.then(() =>
+      request('http://0.0.0.0:8888')
         .get('/output.js')
         .expect(200)
         .then(() => proc.kill('SIGINT'))

--- a/test/fixtures/basic/custom-serve.config.js
+++ b/test/fixtures/basic/custom-serve.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  host: '0.0.0.0',
+  port: 8888,
+};


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Fixes #268 

### Breaking Changes

use <config> as custom serve config file instead of webpack config file from cli, if you are using this alias before, please explicitly append `--config` to it.

### Additional Info