### PR TITLE
docs(readme): add webpack config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ can be useful for setups with multiple configs that share common options for
       filename: './output.js',
       path: path.resolve(__dirname),
     },
+    serve: {},
   };
 ```
 

--- a/README.md
+++ b/README.md
@@ -126,11 +126,10 @@ however, you can utilize any of the options above _in tandem_ with
 can be useful for setups with multiple configs that share common options for
 `webpack-serve`, but require subtle differences.
 
-### `webpack.config.js` example
+### `webpack.config.js` Example
+
 ```js
   const path = require('path');
-
-  const { NamedModulesPlugin } = require('webpack');
 
   module.exports = {
     context: __dirname,
@@ -140,8 +139,6 @@ can be useful for setups with multiple configs that share common options for
       filename: './output.js',
       path: path.resolve(__dirname),
     },
-    plugins: [new NamedModulesPlugin()],
-    serve: {},
   };
 ```
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,25 @@ however, you can utilize any of the options above _in tandem_ with
 can be useful for setups with multiple configs that share common options for
 `webpack-serve`, but require subtle differences.
 
+### `webpack.config.js` example
+```js
+  const path = require('path');
+
+  const { NamedModulesPlugin } = require('webpack');
+
+  module.exports = {
+    context: __dirname,
+    devtool: 'source-map',
+    entry: ['./app.js'],
+    output: {
+      filename: './output.js',
+      path: path.resolve(__dirname),
+    },
+    plugins: [new NamedModulesPlugin()],
+    serve: {},
+  };
+```
+
 ### Webpack Config `serve` Property
 
 `webpack-serve` supports the `serve` property in your webpack config file, which

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ There are a few variations for using the base CLI command, and starting
 `webpack-serve`:
 
 ```console
-  $ webpack-serve ./webpack.config.js
-  $ webpack-serve --config ./webpack.config.js
+$ webpack-serve ./webpack.config.js
+$ webpack-serve --config ./webpack.config.js
 ```
 
 Those two commands are synonymous. Both instruct `webpack-serve` to load the
@@ -102,7 +102,7 @@ config from the specified path. We left the flag in there because some folks
 like to be verbose, so why not.
 
 ```console
-  $ webpack-serve
+$ webpack-serve
 ```
 
 You may also instruct `webpack-serve` to kick off a webpack build without
@@ -129,18 +129,18 @@ can be useful for setups with multiple configs that share common options for
 ### `webpack.config.js` Example
 
 ```js
-  const path = require('path');
+const path = require('path');
 
-  module.exports = {
-    context: __dirname,
-    devtool: 'source-map',
-    entry: ['./app.js'],
-    output: {
-      filename: './output.js',
-      path: path.resolve(__dirname),
-    },
-    serve: {},
-  };
+module.exports = {
+  context: __dirname,
+  devtool: 'source-map',
+  entry: ['./app.js'],
+  output: {
+    filename: './output.js',
+    path: path.resolve(__dirname),
+  },
+  serve: {},
+};
 ```
 
 ### Webpack Config `serve` Property
@@ -154,7 +154,7 @@ Should you find that the `mode` property of your webpack config file needs to be
 set dynamically the following pattern can be used:
 
 ```json
-  mode: process.env.WEBPACK_SERVE ? 'development' : 'production',
+mode: process.env.WEBPACK_SERVE ? 'development' : 'production',
 ```
 
 ## API


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Add simple `webpack` config example, as suggested here: https://github.com/webpack-contrib/webpack-serve/issues/112#issuecomment-386369962
This will make `webpack-serve` more user friendly to beginners.